### PR TITLE
Fix variable names to conventions

### DIFF
--- a/Models/Area.cs
+++ b/Models/Area.cs
@@ -2,17 +2,17 @@
 
 public class Area
 {
-    public int x;
-    public int y;
-    public int w;
-    public int h;
-    public int v;
+    public int X;
+    public int Y;
+    public int W;
+    public int H;
+    public int V;
 
     public Area(int x, int y, int w, int h)
     {
-        this.x = x;
-        this.y = y;
-        this.w = w;
-        this.h = h;
+        this.X = x;
+        this.Y = y;
+        this.W = w;
+        this.H = h;
     }
 }

--- a/Models/Item.cs
+++ b/Models/Item.cs
@@ -7,44 +7,44 @@ using SixLabors.ImageSharp.Processing;
 
 public class Item
 {
-    public int pid;
-    public string name;
-    public Image<Rgba32> image;
-    public Image<Rgba32> logImage;
-    public List<Square> squares;
-    public Page page;
-    public double colorThreshold;
-    public double areaThreshold;
-    public List<List<int>> answers;
+    public int Pid;
+    public string Name;
+    public Image<Rgba32> Image;
+    public Image<Rgba32> LogImage;
+    public List<Square> Squares;
+    public Page Page;
+    public double ColorThreshold;
+    public double AreaThreshold;
+    public List<List<int>> Answers;
     private readonly IJSRuntime js;
 
     public Item(int pid, Page page, double colorThreshold, double areaThreshold, string name,
                 Image<Rgba32> image, IJSRuntime js)
     {
-        this.pid = pid;
-        this.page = page;
-        this.colorThreshold = colorThreshold;
-        this.areaThreshold = areaThreshold;
-        this.name = name;
-        this.image = image;
+        this.Pid = pid;
+        this.Page = page;
+        this.ColorThreshold = colorThreshold;
+        this.AreaThreshold = areaThreshold;
+        this.Name = name;
+        this.Image = image;
         this.js = js;
 
-        this.logImage = image.Clone();
-        this.squares = DetectSquares();
-        this.answers = new();
+        this.LogImage = image.Clone();
+        this.Squares = DetectSquares();
+        this.Answers = new();
     }
 
     public List<Square> DetectSquares()
     {
         var squares = new List<Square>();
-        var margin = new int[] { (int)(image.Width * 0.01), (int)(image.Height * 0.01) };
-        var size = new int[] { (int)(image.Width * 0.3), (int)(image.Height * 0.08) };
+        var margin = new int[] { (int)(Image.Width * 0.01), (int)(Image.Height * 0.01) };
+        var size = new int[] { (int)(Image.Width * 0.3), (int)(Image.Height * 0.08) };
 
         squares.Add(DetectSquare(margin, size));
-        squares.Add(DetectSquare(new int[] { image.Width - margin[0] - size[0], margin[1] }, size));
-        squares.Add(DetectSquare(new int[] { image.Width - margin[0] - size[0],
-                image.Height - margin[1] - size[1] }, size));
-        squares.Add(DetectSquare(new int[] { margin[0], image.Height - margin[1] - size[1] }, size));
+        squares.Add(DetectSquare(new int[] { Image.Width - margin[0] - size[0], margin[1] }, size));
+        squares.Add(DetectSquare(new int[] { Image.Width - margin[0] - size[0],
+                Image.Height - margin[1] - size[1] }, size));
+        squares.Add(DetectSquare(new int[] { margin[0], Image.Height - margin[1] - size[1] }, size));
         return squares;
     }
 
@@ -57,7 +57,7 @@ public class Item
         {
             for (var j = 0; j < size[1]; j++)
             {
-                if (image[i + topLeft[0], j + topLeft[1]].R < 128)
+                if (Image[i + topLeft[0], j + topLeft[1]].R < 128)
                 {
                     pixels[i, j] = index;
                     index++;
@@ -147,7 +147,7 @@ public class Item
             xs.Max() - xs.Min(), ys.Max() - ys.Min(),
             topLeft[0] + (int)xs.Average(), topLeft[1] + (int)ys.Average());
 
-        FillRect(square.x, square.y, square.w, square.h, Rgba32.ParseHex("#FF0000FF"), 0.8f);
+        FillRect(square.X, square.Y, square.W, square.H, Rgba32.ParseHex("#FF0000FF"), 0.8f);
 
         return square;
     }
@@ -208,11 +208,11 @@ public class Item
             }
         }
 
-        var xq = squares[0].cx + (squares[1].cx - squares[0].cx) * u + (squares[3].cx - squares[0].cx) * v
-            + (squares[0].cx - squares[1].cx + squares[2].cx - squares[3].cx) * u * v;
+        var xq = Squares[0].Cx + (Squares[1].Cx - Squares[0].Cx) * u + (Squares[3].Cx - Squares[0].Cx) * v
+            + (Squares[0].Cx - Squares[1].Cx + Squares[2].Cx - Squares[3].Cx) * u * v;
 
-        var yq = squares[0].cy + (squares[1].cy - squares[0].cy) * u + (squares[3].cy - squares[0].cy) * v
-            + (squares[0].cy - squares[1].cy + squares[2].cy - squares[3].cy) * u * v;
+        var yq = Squares[0].Cy + (Squares[1].Cy - Squares[0].Cy) * u + (Squares[3].Cy - Squares[0].Cy) * v
+            + (Squares[0].Cy - Squares[1].Cy + Squares[2].Cy - Squares[3].Cy) * u * v;
 
         return new int[] { (int)xq, (int)yq };
     }
@@ -223,42 +223,42 @@ public class Item
         {
             for (int j = y; j < h + y; j++)
             {
-                logImage[i, j] = new Rgba32(
-                    ((float)logImage[i, j].R * (1.0f - a) + (float)c.R * a) / 255.0f,
-                    ((float)logImage[i, j].G * (1.0f - a) + (float)c.G * a) / 255.0f,
-                    ((float)logImage[i, j].B * (1.0f - a) + (float)c.B * a) / 255.0f);
+                LogImage[i, j] = new Rgba32(
+                    ((float)LogImage[i, j].R * (1.0f - a) + (float)c.R * a) / 255.0f,
+                    ((float)LogImage[i, j].G * (1.0f - a) + (float)c.G * a) / 255.0f,
+                    ((float)LogImage[i, j].B * (1.0f - a) + (float)c.B * a) / 255.0f);
             }
         }
     }
 
     public async Task Recognize()
     {
-        answers = new();
+        Answers = new();
 
-        foreach (var (question, qid) in page.questions.Select((question, qid) => (question, qid)))
+        foreach (var (question, qid) in Page.Questions.Select((question, qid) => (question, qid)))
         {
             List<int> _answers = new();
-            if (question.type == 1)
+            if (question.Type == 1)
             {
-                foreach (var area in question.areas)
+                foreach (var area in question.Areas)
                 {
-                    var topLeft = BiLenearInterpoltation(area.x, area.y);
-                    var bottomRight = BiLenearInterpoltation(area.x + area.w, area.y + area.h);
+                    var topLeft = BiLenearInterpoltation(area.X, area.Y);
+                    var bottomRight = BiLenearInterpoltation(area.X + area.W, area.Y + area.H);
 
                     int count = 0;
                     for (int i = topLeft[0]; i < bottomRight[0]; i++)
                     {
                         for (int j = topLeft[1]; j < bottomRight[1]; j++)
                         {
-                            if (image[i, j].R < (int)((1 - colorThreshold) * 255))
+                            if (Image[i, j].R < (int)((1 - ColorThreshold) * 255))
                             {
                                 count++;
                             }
                         }
                     }
-                    if ((double)count / ((bottomRight[0] - topLeft[0]) * (bottomRight[1] - topLeft[1])) > areaThreshold)
+                    if ((double)count / ((bottomRight[0] - topLeft[0]) * (bottomRight[1] - topLeft[1])) > AreaThreshold)
                     {
-                        _answers.Add(area.v);
+                        _answers.Add(area.V);
                         FillRect(topLeft[0], topLeft[1], bottomRight[0] - topLeft[0], bottomRight[1] - topLeft[1],
                             Rgba32.ParseHex("#00FF00FF"), 0.4f);
                     }
@@ -269,13 +269,13 @@ public class Item
                     }
                 }
             }
-            else if (question.type == 2)
+            else if (question.Type == 2)
             {
-                var area = question.areas[0];
-                var topLeft = BiLenearInterpoltation(area.x, area.y);
-                var bottomRight = BiLenearInterpoltation(area.x + area.w, area.y + area.h);
+                var area = question.Areas[0];
+                var topLeft = BiLenearInterpoltation(area.X, area.Y);
+                var bottomRight = BiLenearInterpoltation(area.X + area.W, area.Y + area.H);
 
-                var cloneImage = image.Clone(img => img
+                var cloneImage = Image.Clone(img => img
                             .Crop(new Rectangle(topLeft[0], topLeft[1],
                                 bottomRight[0] - topLeft[0], bottomRight[1] - topLeft[1]))
                             .Resize(28, 28));
@@ -297,7 +297,7 @@ public class Item
                 {
                     for (int x = 2; x < 26; x++)
                     {
-                        if (cloneImage[x, y].R < (int)((1 - colorThreshold) * 255))
+                        if (cloneImage[x, y].R < (int)((1 - ColorThreshold) * 255))
                         {
                             average_x += (float)x;
                             average_y += (float)y;
@@ -353,18 +353,18 @@ public class Item
                 FillRect(topLeft[0], topLeft[1], bottomRight[0] - topLeft[0], bottomRight[1] - topLeft[1],
                     Rgba32.ParseHex("#0000FFFF"), 0.4f);
             }
-            else if (question.type == 3)
+            else if (question.Type == 3)
             {
             }
 
-            answers.Add(_answers);
+            Answers.Add(_answers);
         }
     }
 
     public string LogImageBase64()
     {
         MemoryStream stream = new();
-        logImage.SaveAsPng(stream);
+        LogImage.SaveAsPng(stream);
         return Convert.ToBase64String(stream.ToArray());
     }
 }

--- a/Models/Page.cs
+++ b/Models/Page.cs
@@ -4,10 +4,10 @@ using System.Collections.Generic;
 
 public class Page
 {
-    public List<Question> questions;
+    public List<Question> Questions;
 
     public Page()
     {
-        questions = new List<Question>();
+        Questions = new List<Question>();
     }
 }

--- a/Models/Question.cs
+++ b/Models/Question.cs
@@ -3,12 +3,12 @@
 using System.Collections.Generic;
 public class Question
 {
-    public string? text;
-    public int type;
-    public List<Area> areas;
+    public string? Text;
+    public int Type;
+    public List<Area> Areas;
 
     public Question()
     {
-        areas = new List<Area>();
+        Areas = new List<Area>();
     }
 }

--- a/Models/Repository.cs
+++ b/Models/Repository.cs
@@ -2,6 +2,6 @@
 
 public class Repository
 {
-    public string? name { get; set; }
-    public List<RepositoryPayload>? payloads { get; set; }
+    public string? Name { get; set; }
+    public List<RepositoryPayload>? Payloads { get; set; }
 }

--- a/Models/RepositoryPayload.cs
+++ b/Models/RepositoryPayload.cs
@@ -2,6 +2,6 @@
 
 public class RepositoryPayload
 {
-    public string? name { get; set; }
-    public List<List<dynamic>>? values { get; set; }
+    public string? Name { get; set; }
+    public List<List<dynamic>>? Values { get; set; }
 }

--- a/Models/Square.cs
+++ b/Models/Square.cs
@@ -2,20 +2,20 @@
 
 public class Square
 {
-    public int x;
-    public int y;
-    public int w;
-    public int h;
-    public int cx;
-    public int cy;
+    public int X;
+    public int Y;
+    public int W;
+    public int H;
+    public int Cx;
+    public int Cy;
 
     public Square(int x, int y, int w, int h, int cx, int cy)
     {
-        this.x = x;
-        this.y = y;
-        this.w = w;
-        this.h = h;
-        this.cx = cx;
-        this.cy = cy;
+        this.X = x;
+        this.Y = y;
+        this.W = w;
+        this.H = h;
+        this.Cx = cx;
+        this.Cy = cy;
     }
 }

--- a/Models/Survey.cs
+++ b/Models/Survey.cs
@@ -15,23 +15,23 @@ using System.Threading.Tasks;
 
 public class Survey
 {
-    public string? title;
-    public List<RepositoryPayload> repositoryPayloads = new();
+    public string? Title;
+    public List<RepositoryPayload> RepositoryPayloads = new();
 
-    public IList<IBrowserFile> imageFiles;
-    public double areaThreshold;
-    public double colorThreshold;
-    public List<Page> pages;
+    public IList<IBrowserFile> ImageFiles;
+    public double AreaThreshold;
+    public double ColorThreshold;
+    public List<Page> Pages;
 
-    public Dictionary<string, List<List<int>>> answers;
-    public string selectedLogImage;
+    public Dictionary<string, List<List<int>>> Answers;
+    public string SelectedLogImage;
 
     public Survey()
     {
-        imageFiles = new List<IBrowserFile>();
-        pages = new();
-        answers = new();
-        selectedLogImage = string.Empty;
+        ImageFiles = new List<IBrowserFile>();
+        Pages = new();
+        Answers = new();
+        SelectedLogImage = string.Empty;
     }
 
     public async Task FetchRepository(string surveyId)
@@ -42,19 +42,19 @@ public class Survey
         var repository = await client.GetFromJsonAsync<Repository>(url);
         if (repository != null)
         {
-            this.title = repository.name;
-            this.repositoryPayloads = repository.payloads!;
+            this.Title = repository.Name;
+            this.RepositoryPayloads = repository.Payloads!;
         }
     }
 
     public void SetupPositionsFromRepository(string? repositoryPayloadName)
     {
-        foreach (var payload in this.repositoryPayloads)
+        foreach (var payload in this.RepositoryPayloads)
         {
-            if (payload.name == repositoryPayloadName && payload.values != null)
+            if (payload.Name == repositoryPayloadName && payload.Values != null)
             {
-                pages = new();
-                var row = payload.values[0];
+                Pages = new();
+                var row = payload.Values[0];
 
                 List<int> vs = new();
                 for (int i = 1; i <= row.Count / 4; i++)
@@ -68,18 +68,18 @@ public class Survey
                     }
                 }
 
-                for (int i = 3; i < payload.values.Count; i++)
+                for (int i = 3; i < payload.Values.Count; i++)
                 {
-                    row = payload.values[i];
+                    row = payload.Values[i];
                     int pageNumber = row[2].GetInt32();
-                    while (pages.Count() < pageNumber)
+                    while (Pages.Count() < pageNumber)
                     {
-                        pages.Add(new Page());
+                        Pages.Add(new Page());
                     }
 
                     Question question = new();
-                    question.text = row[1].ToString();
-                    question.type = row[3].GetInt32();
+                    question.Text = row[1].ToString();
+                    question.Type = row[3].GetInt32();
 
                     for (int j = 1; j <= row.Count / 4; j++)
                     {
@@ -89,15 +89,15 @@ public class Survey
                                 row[j * 4 + 1].GetInt32(),
                                 row[j * 4 + 2].GetInt32(),
                                 row[j * 4 + 3].GetInt32());
-                            area.v = vs[j - 1];
+                            area.V = vs[j - 1];
 
-                            question.areas.Add(area);
+                            question.Areas.Add(area);
                         }
                         catch (Exception)
                         {
                         }
                     }
-                    pages[pageNumber - 1].questions.Add(question);
+                    Pages[pageNumber - 1].Questions.Add(question);
                 }
             }
         }
@@ -105,7 +105,7 @@ public class Survey
 
     public void SetupPositionsFromFile(MemoryStream ms)
     {
-        pages = new();
+        Pages = new();
         var workbook = new XSSFWorkbook(ms);
         var sheet = workbook.GetSheetAt(0);
         var row = sheet.GetRow(0);
@@ -131,14 +131,14 @@ public class Survey
             {
                 row = sheet.GetRow(i);
                 pageNumber = Convert.ToInt32(row.GetCell(2).NumericCellValue);
-                while (pages.Count() < pageNumber)
+                while (Pages.Count() < pageNumber)
                 {
-                    pages.Add(new Page());
+                    Pages.Add(new Page());
                 }
 
                 question = new();
-                question.text = row.GetCell(1).ToString();
-                question.type = Convert.ToInt32(row.GetCell(3).NumericCellValue);
+                question.Text = row.GetCell(1).ToString();
+                question.Type = Convert.ToInt32(row.GetCell(3).NumericCellValue);
             }
             catch (Exception)
             {
@@ -153,30 +153,30 @@ public class Survey
                         Convert.ToInt32(row.GetCell(j * 4 + 1).NumericCellValue),
                         Convert.ToInt32(row.GetCell(j * 4 + 2).NumericCellValue),
                         Convert.ToInt32(row.GetCell(j * 4 + 3).NumericCellValue));
-                    area.v = vs[j - 1];
+                    area.V = vs[j - 1];
 
-                    question.areas.Add(area);
+                    question.Areas.Add(area);
                 }
                 catch (Exception)
                 {
                 }
             }
-            pages[pageNumber - 1].questions.Add(question);
+            Pages[pageNumber - 1].Questions.Add(question);
         }
     }
 
     public async Task Recognize(int index, IJSRuntime js, bool updateLogImage = false)
     {
         MemoryStream stream = new();
-        await imageFiles[index].OpenReadStream(1024 * 1024 * 24).CopyToAsync(stream);
+        await ImageFiles[index].OpenReadStream(1024 * 1024 * 24).CopyToAsync(stream);
         var image = Image.Load<Rgba32>(stream.ToArray());
-        Item item = new(index, pages[index % pages.Count()], colorThreshold, areaThreshold,
-                        imageFiles[index].Name, image, js);
+        Item item = new(index, Pages[index % Pages.Count()], ColorThreshold, AreaThreshold,
+                        ImageFiles[index].Name, image, js);
         await item.Recognize();
-        answers[item.name] = item.answers;
+        Answers[item.Name] = item.Answers;
         if (updateLogImage)
         {
-            selectedLogImage = item.LogImageBase64();
+            SelectedLogImage = item.LogImageBase64();
         }
     }
 
@@ -192,9 +192,9 @@ public class Survey
         cell = row.CreateCell(1);
         cell.SetCellValue("File");
         int questionIndex = 0;
-        foreach (var page in pages)
+        foreach (var page in Pages)
         {
-            foreach (var question in page.questions)
+            foreach (var question in page.Questions)
             {
                 cell = row.CreateCell(questionIndex + 2);
                 cell.SetCellValue(questionIndex + 1);
@@ -205,12 +205,12 @@ public class Survey
         // second header
         row = sheet.CreateRow(1);
         questionIndex = 0;
-        foreach (var page in pages)
+        foreach (var page in Pages)
         {
-            foreach (var question in page.questions)
+            foreach (var question in page.Questions)
             {
                 cell = row.CreateCell(questionIndex + 2);
-                cell.SetCellValue(question.text);
+                cell.SetCellValue(question.Text);
                 questionIndex++;
             }
         }
@@ -218,10 +218,10 @@ public class Survey
         int rowIndex = 1;
         int itemIndex = 0;
         List<string> names = new();
-        foreach (var _answers in answers.OrderBy(d => d.Key, StringComparison.OrdinalIgnoreCase.WithNaturalSort()))
+        foreach (var _answers in Answers.OrderBy(d => d.Key, StringComparison.OrdinalIgnoreCase.WithNaturalSort()))
         {
             // first page
-            if (itemIndex % pages.Count == 0)
+            if (itemIndex % Pages.Count == 0)
             {
                 rowIndex++;
                 row = sheet.CreateRow(rowIndex);
@@ -259,7 +259,7 @@ public class Survey
             }
 
             // last page
-            if ((itemIndex + 1) % pages.Count == 0 || itemIndex + 1 == answers.Count)
+            if ((itemIndex + 1) % Pages.Count == 0 || itemIndex + 1 == Answers.Count)
             {
                 cell = row.CreateCell(1);
                 cell.SetCellValue(string.Join(";", names));

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -16,9 +16,9 @@
     <MudCardHeader>
         <CardHeaderContent>
             <MudText Typo="Typo.h6">
-                @if (survey.title != null)
+                @if (survey.Title != null)
                 {
-                    @survey.title
+                    @survey.Title
                 }
                 else if (isLoadingRepository)
                 {
@@ -38,9 +38,9 @@
                 <MudItem xs="12">
                     <MudSelect @bind-Value="@repositoryPayloadName" T="string" Variant="Variant.Outlined"
                         AnchorOrigin="Origin.BottomCenter">
-                        @foreach (var payload in survey.repositoryPayloads)
+                        @foreach (var payload in survey.RepositoryPayloads)
                         {
-                            <MudSelectItem T="string" Value=@payload.name />
+                            <MudSelectItem T="string" Value=@payload.Name />
                         }
                     </MudSelect>
                 </MudItem>
@@ -142,7 +142,7 @@
     <MudCard Style="margin: 2em 0; height: 1000;">
     <MudCardHeader>
         <CardHeaderContent>
-            <MudText Typo="Typo.body1">@survey.imageFiles[logIndex].Name</MudText>
+            <MudText Typo="Typo.body1">@survey.ImageFiles[logIndex].Name</MudText>
         </CardHeaderContent>
         <CardHeaderActions>
             @if (isLoadingLogImage)
@@ -176,11 +176,11 @@
                     }
                     else
                     {
-                        <img src="data:image/png;base64,@survey.selectedLogImage" style="width: 80%;" />
+                        <img src="data:image/png;base64,@survey.SelectedLogImage" style="width: 80%;" />
                     }
                 </MudItem>
                 <MudItem xs="2" Class="d-flex align-center justify-center">
-                    @if (logIndex < survey.imageFiles.Count - 1 && !isLoadingLogImage)
+                    @if (logIndex < survey.ImageFiles.Count - 1 && !isLoadingLogImage)
                     {
                         <MudFab StartIcon="@Icons.Material.Filled.ChevronRight" Color="Color.Primary"
                             OnClick=IncrementLogIndex />
@@ -236,7 +236,7 @@
             try
             {
                 await survey.FetchRepository(surveyId);
-                repositoryPayloadName = survey.repositoryPayloads[0].name;
+                repositoryPayloadName = survey.RepositoryPayloads[0].Name;
                 hasLayout = true;
             }
             catch (Exception)
@@ -309,10 +309,10 @@
 
         processed = 0;
         progressMessage = $"{processed} / {imageFiles.Count}";
-        survey.imageFiles = imageFiles.OrderBy(x => x.Name, StringComparison.OrdinalIgnoreCase.WithNaturalSort()).ToList();
-        survey.areaThreshold = areaThreshold / 100.0;
-        survey.colorThreshold = colorThreshold / 100.0;
-        survey.answers = new();
+        survey.ImageFiles = imageFiles.OrderBy(x => x.Name, StringComparison.OrdinalIgnoreCase.WithNaturalSort()).ToList();
+        survey.AreaThreshold = areaThreshold / 100.0;
+        survey.ColorThreshold = colorThreshold / 100.0;
+        survey.Answers = new();
         isCompleted = false;
         logIndex = 0;
         stopwatch = new();
@@ -370,13 +370,13 @@
         "FileSaveAs",
         $"Mark2-Log-{Path.GetFileNameWithoutExtension(imageFiles[logIndex].Name)}.png",
         "image/png",
-        survey.selectedLogImage
+        survey.SelectedLogImage
         );
     }
 
     private async Task IncrementLogIndex()
     {
-        if (logIndex < survey.imageFiles.Count - 1)
+        if (logIndex < survey.ImageFiles.Count - 1)
         {
             logIndex++;
             isLoadingLogImage = true;


### PR DESCRIPTION
[名前付け規則](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names#naming-conventions)に従ってパブリック メンバーの名前を PascalCase に修正してみました。

- WinMerge（差分比較ツール）の「大文字小文字を区別しない」の機能を利用して差分がないことを確認しました。
- 修正後に[サンプルファイル](https://onedrive.live.com/?authkey=%21AN4MkrdfgqcG2so&id=36B3FC7ED39B7F88%21103306&cid=36B3FC7ED39B7F88)を使用して動作することを確認しました。
- 修正前後で実行後のダウンロード ファイルの内容が変わらないことをを比較しましたが一致しませんでした。（Mark2-Result-yyyyMMdd_HHmmss.xlsx）

### この変更を加えた経緯
[Blazorアプリで2年間放置していたコードの警告と向き合います](https://qiita.com/kaorumori/items/a8d03f451a9087573cda)にて以下のように書かれていたため。

> 変数名の命名規則を公式ドキュメントに準拠させることを思い出しました。現状では変数名がcamelCaseだったり、Rubyで書いたプロトタイプの影響でsnake_caseだったりしています。

### ご挨拶
初めまして、green です。
Blazor が好きで「[Blazor WebAssemblyでつくったマークシートシステム Mark2をオープンソースとして公開](https://qiita.com/kaorumori/items/5b7255e3244159b082d3)」の記事と出会い、自分が力になれそうなところはないかと思いまずは一つプッシュしてみました。

下記添付のメッセージもなるべく解消したかったのですがテスト方法などを把握していない状態であれこれ変更してもご迷惑かなと思い、まずは差分が出ない変更（安全度が高い）のみをさせていただきました。

![image](https://github.com/mark2-omr/Mark2/assets/137851060/700c37bf-94f1-44fd-b7a6-ce50a448279f)

