### PR TITLE
Fix IDE0003

### DIFF
--- a/Models/Area.cs
+++ b/Models/Area.cs
@@ -10,9 +10,9 @@ public class Area
 
     public Area(int x, int y, int w, int h)
     {
-        this.X = x;
-        this.Y = y;
-        this.W = w;
-        this.H = h;
+        X = x;
+        Y = y;
+        W = w;
+        H = h;
     }
 }

--- a/Models/Item.cs
+++ b/Models/Item.cs
@@ -16,7 +16,7 @@ public class Item
     public double ColorThreshold;
     public double AreaThreshold;
     public List<List<int>> Answers;
-    private readonly IJSRuntime js;
+    private readonly IJSRuntime _js;
 
     public Item(int pid, Page page, double colorThreshold, double areaThreshold, string name,
                 Image<Rgba32> image, IJSRuntime js)
@@ -27,7 +27,7 @@ public class Item
         this.AreaThreshold = areaThreshold;
         this.Name = name;
         this.Image = image;
-        this.js = js;
+        this._js = js;
 
         this.LogImage = image.Clone();
         this.Squares = DetectSquares();
@@ -342,7 +342,7 @@ public class Item
 
                 try
                 {
-                    var ans = await js.InvokeAsync<int>("runOnnxRuntime", data);
+                    var ans = await _js.InvokeAsync<int>("runOnnxRuntime", data);
                     _answers.Add(ans);
                 }
                 catch (Exception ex)

--- a/Models/Item.cs
+++ b/Models/Item.cs
@@ -21,17 +21,17 @@ public class Item
     public Item(int pid, Page page, double colorThreshold, double areaThreshold, string name,
                 Image<Rgba32> image, IJSRuntime js)
     {
-        this.Pid = pid;
-        this.Page = page;
-        this.ColorThreshold = colorThreshold;
-        this.AreaThreshold = areaThreshold;
-        this.Name = name;
-        this.Image = image;
-        this._js = js;
+        Pid = pid;
+        Page = page;
+        ColorThreshold = colorThreshold;
+        AreaThreshold = areaThreshold;
+        Name = name;
+        Image = image;
+        _js = js;
 
-        this.LogImage = image.Clone();
-        this.Squares = DetectSquares();
-        this.Answers = new();
+        LogImage = image.Clone();
+        Squares = DetectSquares();
+        Answers = new();
     }
 
     public List<Square> DetectSquares()

--- a/Models/Square.cs
+++ b/Models/Square.cs
@@ -11,11 +11,11 @@ public class Square
 
     public Square(int x, int y, int w, int h, int cx, int cy)
     {
-        this.X = x;
-        this.Y = y;
-        this.W = w;
-        this.H = h;
-        this.Cx = cx;
-        this.Cy = cy;
+        X = x;
+        Y = y;
+        W = w;
+        H = h;
+        Cx = cx;
+        Cy = cy;
     }
 }

--- a/Models/Survey.cs
+++ b/Models/Survey.cs
@@ -42,14 +42,14 @@ public class Survey
         var repository = await client.GetFromJsonAsync<Repository>(url);
         if (repository != null)
         {
-            this.Title = repository.Name;
-            this.RepositoryPayloads = repository.Payloads!;
+            Title = repository.Name;
+            RepositoryPayloads = repository.Payloads!;
         }
     }
 
     public void SetupPositionsFromRepository(string? repositoryPayloadName)
     {
-        foreach (var payload in this.RepositoryPayloads)
+        foreach (var payload in RepositoryPayloads)
         {
             if (payload.Name == repositoryPayloadName && payload.Values != null)
             {


### PR DESCRIPTION
9d653d1 にてクラスのフィールド名を変更したことに伴い、`this` の修飾を省略することができるようになったので削除しました。
https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009

- 修正後に[サンプルファイル](https://onedrive.live.com/?authkey=%21AN4MkrdfgqcG2so&id=36B3FC7ED39B7F88%21103306&cid=36B3FC7ED39B7F88)を使用して動作することを確認しました。
- ダウンロードしたファイルの内容は確認していません。（Mark2-Result-yyyyMMdd_HHmmss.xlsx）
